### PR TITLE
챗봇 메모리 및 선호 정보 필터링 기능 구현

### DIFF
--- a/steamate/chatmate/utils.py
+++ b/steamate/chatmate/utils.py
@@ -173,7 +173,7 @@ def chatbot_call(user_input, session_id, genre=None, game=None, appid=None):
             } if genre else None,
             "filter": {
                 "appid": {
-                    "$and": appid
+                    "$not": appid
                 }
             } if appid else None
         }

--- a/steamate/chatmate/views.py
+++ b/steamate/chatmate/views.py
@@ -6,7 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from .models import ChatSession, ChatMessage
 from .serializers import ChatSessionSerializer, ChatMessageSerializer
 
-from .utils import chatbot_call
+from .utils import chatbot_call, bring_session_history
 
 
 # Create your views here.
@@ -15,11 +15,14 @@ class ChatSessionAPIView(APIView):
     # 인증되지 않은 유저가 접근하면 401에러를 반환
     permission_classes = [IsAuthenticated]
 
+    # 세션 목록 조회
     def get(self, request):
         sessions = ChatSession.objects.all()
         serializer = ChatSessionSerializer(sessions, many=True)
+        
         return Response(serializer.data, status=status.HTTP_200_OK)
     
+    # 세션 생성
     def post(self, request):
         serializer = ChatSessionSerializer(data=request.data)
         if serializer.is_valid(raise_exception=True):
@@ -32,16 +35,28 @@ class ChatMessageAPIView(APIView):
     # 인증되지 않은 유저가 접근하면 401에러를 반환
     permission_classes = [IsAuthenticated]
 
+    # 세션 내역 조회
     def get(self, request, session_id):
         session = ChatSession.objects.get(pk=session_id)
+        # RDB에 있는 대화 내역을 메모리에 저장하는 함수
+        # 지금은 대화 내역을 불러오고 30분이 지나면 메모리에서 삭제 됨
+        # 추후 대화 내역을 저장하고 30분이 지나도 메모리에 남아있도록 수정 필요(튜터님께 여쭤보기)
+        bring_session_history(session_id)
         messages = session.chat_messages.all()
         serializer = ChatMessageSerializer(messages, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
     
+    # 대화 내역 생성
     def post(self, request, session_id):
         session = ChatSession.objects.get(pk=session_id)
         serializer = ChatMessageSerializer(data=request.data)
         if serializer.is_valid(raise_exception=True):
-            chatbot_message = chatbot_call(request.data["user_message"], session_id)
+            # 선호장르 가져오기
+            genre = [genre.genre_name for genre in request.user.preferred_genre.all()]
+            # 선호 게임 정보 가져오기(appid, game_title)
+            appid = [game.appid for game in request.user.preferred_game.all()]
+            game = [game.title for game in request.user.preferred_game.all()]
+            # 챗봇 메시지 생성
+            chatbot_message = chatbot_call(request.data["user_message"], session_id, genre=genre, game=game, appid=appid)
             serializer.save(session_id=session, chatbot_message=chatbot_message)
             return Response(serializer.data, status=status.HTTP_200_OK)

--- a/steamate/requirements.txt
+++ b/steamate/requirements.txt
@@ -14,3 +14,4 @@ langchain_community==0.3.19
 langchain_openai==0.3.7
 langchain-postgres==0.0.11
 pandas==2.2.3
+cachetools==5.5.2


### PR DESCRIPTION
## 🔍 개요
대화내역조회api를 최초 호출할 때 챗봇 대화 내역을 RDB에서 메모리로 저장(유효기간 30분),
유저 선호 게임, 장르를 메타데이터에서 필터링(게임: 제외, 장르 : 포함) 구현

## ✅ 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항을 체크해주세요. -->
- [x] PR 제목은 명확한가요?
- [ ] 코드 스타일 가이드를 준수했나요?
- [ ] 관련된 이슈가 있나요? (있다면 아래에 연결해주세요.)
- [x] 테스트를 거쳤나요?

## 🔗 관련 이슈
없음

## 📎 변경 사항
requirments.txt
utils.py
views.py

## 📸 스크린샷
없음

## 💬 추가 설명
없음