### PR TITLE
:recycle: refresh_token에서 refresh로 통일

### DIFF
--- a/steamate/account/views.py
+++ b/steamate/account/views.py
@@ -195,8 +195,8 @@ class SteamCallbackAPIView(APIView):
         # Steam ID 회원가입
         return Response({
             "new_user":True,
-            "maessage":"Steam 계정 호출 완료",
-            "Steam_id":{steam_id}}, status=status.HTTP_200_OK)
+            "message":"Steam 계정 호출 완료",
+            "steam_id":{steam_id}}, status=status.HTTP_200_OK)
 
 
 

--- a/steamate/account/views.py
+++ b/steamate/account/views.py
@@ -347,7 +347,7 @@ class MyPageAPIView(APIView):
             return Response({"error": "You do not have permission to delete this user"},status=status.HTTP_403_FORBIDDEN)
         
         user = self.get_user(pk)
-        refresh_token = request.data.get("refresh_token")
+        refresh_token = request.data.get("refresh")
         
         if not refresh_token:
             return Response({"error":"Refresh token is required for account deletion."}, status=status.HTTP_400_BAD_REQUEST)

--- a/steamate/account/views.py
+++ b/steamate/account/views.py
@@ -181,7 +181,8 @@ class SteamCallbackAPIView(APIView):
             return Response({
                 "new_user":False,
                 "message": "Steam 계정 호출 완료",
-                "steam_id":{steam_id}}, status=status.HTTP_200_OK)
+                "steam_id":steam_id
+                }, status=status.HTTP_200_OK)
 
 
         # Steam ID 로그인
@@ -196,7 +197,8 @@ class SteamCallbackAPIView(APIView):
         return Response({
             "new_user":True,
             "message":"Steam 계정 호출 완료",
-            "steam_id":{steam_id}}, status=status.HTTP_200_OK)
+            "steam_id":steam_id
+            }, status=status.HTTP_200_OK)
 
 
 


### PR DESCRIPTION
## 🔍 개요
<!-- 이번 PR에서 변경된 내용이나 추가된 기능에 대해 간략하게 설명해주세요. -->
request.data.get()에서 "refresh_token"과 "refresh"이 함께 사용되고 있어서 body에서 가져오는 refresh token은 "refresh"로 통일했습니다.

## ✅ 체크리스트
<!-- PR을 생성하기 전에 확인해야 할 사항을 체크해주세요. -->
- [x] PR 제목은 명확한가요?
- [x] 코드 스타일 가이드를 준수했나요?
- [ ] 관련된 이슈가 있나요? (있다면 아래에 연결해주세요.)
- [x] 테스트를 거쳤나요?

## 🔗 관련 이슈
없음

## 📎 변경 사항
<!-- 변경된 파일이나 주요 코드 변경 사항을 나열해주세요. -->
회원 탈퇴에서 refresh token을 "refresh_token"으로 가져오는 것을 "refresh"로 변경
account.views.py 198, 199 line 오탈자 수정
"steam_id":{"steam_id} 가 잘못된 것으로 "steam_id":steam_id 로 수정
## 📸 스크린샷
<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 💬 추가 설명
<!-- 리뷰어가 참고할 만한 추가적인 내용을 적어주세요. -->